### PR TITLE
Add grouped name filter to initialize plugins

### DIFF
--- a/assets/js/yoast-toggle.js
+++ b/assets/js/yoast-toggle.js
@@ -1,5 +1,5 @@
 var Yoast_Plugin_Toggler = {
-	toggle_plugin: function( plugin, nonce ) {
+	toggle_plugin: function( group, plugin, nonce ) {
 		"use strict";
 
 		jQuery.getJSON(
@@ -7,6 +7,7 @@ var Yoast_Plugin_Toggler = {
 			{
 				action: "toggle_version",
 				ajax_nonce: nonce,
+				group: group,
 				plugin: plugin
 			},
 			function( response ) {


### PR DESCRIPTION
## Why?
Due to my habit of adding releases to the plugins directory. I was hoping to extend this plugin to include them in the toggle menu.

## What?
I found out this toggles between two in a namespace. I did not want to write a separate plugin to extend the array every time. So instead it now scans all the plugins and filters them by name and groups them by the regex groups.
There can now be more than 2 plugins per group. Still only 1 active plugin per group.

**Plugins folder**
<img width="199" alt="plugins" src="https://user-images.githubusercontent.com/35524806/42722850-a97028b2-8753-11e8-9948-d78817f58a8f.png">
**The toggle menu**
<img width="245" alt="menu" src="https://user-images.githubusercontent.com/35524806/42722851-ab0552e2-8753-11e8-8caa-019e388ffc81.png">

## Changes
- Initializes the plugins array with WordPress's `get_plugins` filtered by name and grouped according to the regex.
- Added the filter `yoast_plugin_toggler_filter` to alter the `grouped_name_filter` regex.
- Implemented support for more than 2 plugins per group.
